### PR TITLE
alt-cmd-w conflicts with default atom keymap (use ctrl-cmd-w instead)

### DIFF
--- a/keymaps/close-other-tabs.cson
+++ b/keymaps/close-other-tabs.cson
@@ -1,2 +1,2 @@
 'atom-workspace':
-  'alt-cmd-w': 'close-other-tabs:close-other-tabs'
+  'ctrl-cmd-w': 'close-other-tabs:close-other-tabs'


### PR DESCRIPTION
Not only is ctrl-cmd-w free by default, but it's consistent with TextMate etc.
